### PR TITLE
Adds comment type metadata

### DIFF
--- a/riscv.lang
+++ b/riscv.lang
@@ -5,6 +5,7 @@
     <metadata>
         <property name="mimetypes">text/x-riscv-asm</property>
         <property name="globs">*.S</property>
+        <property name="line-comment-start">#</property>
     </metadata>
 
     <styles>


### PR DESCRIPTION
Allows plugins and external tools that use comment type metadata (such as the code block comment plugin) to work with risc-v assembly language.